### PR TITLE
Ajout de l'option `text_mode` pour envoyer des messages formatés

### DIFF
--- a/core/class/signal.class.php
+++ b/core/class/signal.class.php
@@ -293,10 +293,14 @@ class signal extends eqLogic {
 		
 		$sender = trim($this->getConfiguration("numero"));
 		$recipient = isset($options['number']) ? trim($options['number']) : $sender;
-      
-		$curl = 'curl -X POST -H "Content-Type: application/json" \'http://localhost:' . 
+      	// "styled" demande à l'API d'interpréter le balisage du message : **gras**, *italique*,
+      	// `monospace`, ||spoiler||. Défaut "normal", donc aucun changement pour les envois existants.
+      	// Liste blanche : $options vient d'un scénario et finit interpolé dans une commande shell.
+		$textMode = (isset($options['text_mode']) && $options['text_mode'] === 'styled') ? 'styled' : 'normal';
+
+		$curl = 'curl -X POST -H "Content-Type: application/json" \'http://localhost:' .
 				$port . '/v2/send\' -d \'{"message": "' .
-				$message . '", "number": "' . $sender . '", "recipients": [ "' . $recipient . '" ]}\'';
+				$message . '", "number": "' . $sender . '", "recipients": [ "' . $recipient . '" ], "text_mode": "' . $textMode . '"}\'';
 		
 		log::add('signal', 'debug', '[ENVOI MESSAGE] Requête:<br/>' . $curl);
 		$send = shell_exec($curl);
@@ -486,9 +490,12 @@ class signal extends eqLogic {
 
 		$sender = trim($this->getConfiguration("numero"));
 		$recipient = isset($options['number']) ? trim($options['number']) : $sender;
+      	// Même option que dans send(), sans quoi le balisage fonctionnerait sur un message seul et
+      	// disparaîtrait dès qu'on y joint un fichier.
+		$textMode = (isset($options['text_mode']) && $options['text_mode'] === 'styled') ? 'styled' : 'normal';
 
 		$curl = 'B64TEMPFILE="$(' . system::getCmdSudo() . 'base64 ' . $tmpFolder . "/" . $filename .')" ' . //on met le fichier en b64 dans une variable
-          		'&& printf \'{"message": "%s", "base64_attachments": ["\'"$B64TEMPFILE"\'"], "number": "' . $sender . '", "recipients": [ "' . $recipient . '" ]}\' "' . $cleanedMessage . '" | ' . // on prépare le json à envoyer à l'api
+          		'&& printf \'{"message": "%s", "base64_attachments": ["\'"$B64TEMPFILE"\'"], "number": "' . $sender . '", "recipients": [ "' . $recipient . '" ], "text_mode": "' . $textMode . '"}\' "' . $cleanedMessage . '" | ' . // on prépare le json à envoyer à l'api
 				'curl -X POST -H "Content-Type: application/json" -d @- \'http://localhost:' . $port . '/v2/send\''; // envoi du pipe à l'api
 
 		log::add('signal', 'debug', '[ENVOI MESSAGE] Requête:<br/>' . $curl);


### PR DESCRIPTION
Bonjour,

Merci pour ce plugin, je l'utilise quotidiennement pour les notifications de ma domotique.

Je cherchais à mettre **un mot** en gras dans une alerte, et il n'y a pas de moyen d'y arriver aujourd'hui. Signal ne transporte pas le style dans le texte : il voyage à côté, sous forme de *body ranges*. Deux voies existent donc, `--text-style` de `signal-cli` qui demande de calculer soi-même des offsets en unités UTF-16, ou le champ `text_mode` de l'API `signal-cli-rest-api`, qui fait le travail à partir du balisage présent dans le corps du message.

Cette PR ajoute le second.

## Ce que ça change

Le champ `text_mode` est ajouté au payload `/v2/send`, piloté par une **option d'appel** et non par un réglage du plugin, avec `normal` par défaut. Les envois existants sont donc strictement inchangés, et il n'y a pas d'écran de configuration supplémentaire à traduire dans les neuf langues du plugin.

```php
$options = array("background" => "1",
                 "title"      => "",
                 "message"    => "Frigo **OUVERT** depuis 15 minutes",
                 "number"     => "group.…",
                 "text_mode"  => "styled");
cmd::byString('#[Baie][Signal][Envoi message]#')->execCmd($options);
```

En mode `styled`, l'API interprète `**gras**`, `*italique*`, `` `monospace` `` et `||spoiler||`.

`signalCmd::execute()` relaie déjà `$_options` tel quel à `send()` et `sendFile()`, il n'y avait donc rien à modifier de ce côté.

## Points d'attention

**Les deux chemins d'envoi sont couverts.** Sans le hunk dans `sendFile()`, le formatage fonctionnerait sur un message seul et cesserait silencieusement dès qu'on y joint un fichier — le genre d'incohérence coûteuse à diagnostiquer.

**La valeur est filtrée par liste blanche** (`=== 'styled'`, sinon `'normal'`) plutôt qu'interpolée telle quelle : `$options` vient d'un scénario et finit dans une commande shell.

**Une ligne de bruit** dans le diff : une espace en fin de ligne perdue sur la ligne du `$curl` de `send()`, sans effet.

## Testé

Sur Jeedom avec le plugin en 0.100, envoi vers un groupe : gras et italique rendus correctement côté application Signal, et un envoi sans `text_mode` reste identique à avant.

## Deux suites possibles, si ça vous intéresse

1. **Exposer l'option dans l'éditeur graphique de scénario** — un `<select>` dans `core/template/scenario/cmd.send.html` et son équivalent avec pièces jointes. Je ne l'ai pas incluse ici parce qu'elle suppose aussi de substituer un placeholder dans `getWidgetTemplateCode()`, et que je n'avais pas de quoi tester l'interface sérieusement. Je la fais volontiers en PR séparée si vous la souhaitez.

2. **Remplacer l'échappement manuel du message par `json_encode`.** Aujourd'hui `send()` fait `str_replace('"', '\"', …)` puis inline le résultat dans une chaîne JSON écrite à la main ; un message contenant un antislash ou certains caractères peut casser le payload. C'est une vraie correction, mais elle touche tous les envois — elle mérite sa propre PR, à part de cet ajout d'option.

Bien cordialement.
